### PR TITLE
Add Kirby panel integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to the "Kirby CMS Developer Toolkit" extension will be docum
 
 ### Added
 
+- **Kirby Panel Integration**: Access the Kirby Panel directly within VS Code
+  - WebView-based Panel embedded in VS Code editor
+  - Alternative browser-based Panel access
+  - Automatic Panel URL detection via localhost probing
+  - Manual Panel URL configuration for remote/custom setups
+  - Status bar indicator showing Panel server status
+  - Panel reload functionality
+  - Session persistence within VS Code session
+  - Multiple detection strategies: configuration setting, port probing, package.json parsing, manual entry
+  - Commands:
+    - `Kirby: Open Panel in WebView` - Open Panel in embedded WebView
+    - `Kirby: Open Panel in Browser` - Open Panel in default browser
+    - `Kirby: Reload Panel` - Refresh Panel WebView content
+    - `Kirby: Configure Panel URL` - Manually set Panel URL
+  - Configuration settings:
+    - `kirby.enablePanelIntegration` (default: true) - Enable Panel integration features
+    - `kirby.panelUrl` (default: "") - Manual Panel URL configuration
+    - `kirby.panelAutoDetect` (default: true) - Auto-detect Panel URL
+    - `kirby.panelOpenInWebView` (default: true) - Open in WebView by default
+  - Comprehensive error handling with helpful troubleshooting messages
+  - Security: URL validation and XSS protection for iframe content
+  - Full test coverage for Panel detection and WebView lifecycle
+
 - **Kirby API IntelliSense**: Intelligent autocompletion and inline documentation for Kirby CMS API
   - Automatic detection and integration with Intelephense PHP language server
   - PHP stub files for core Kirby classes: Page, Site, File, User, Kirby/App, Field

--- a/README.md
+++ b/README.md
@@ -553,6 +553,108 @@ When the [Kirby Snippet Controller plugin](https://github.com/lukaskleinschmidt/
 - Automatic type-hint injection when creating new snippet controller files
 - Supports nested snippets (e.g., `partials/menu.controller.php`)
 
+### 12. Kirby Panel Integration
+
+Access the Kirby Panel directly within VS Code, eliminating context switching between your editor and browser during development.
+
+**Features:**
+- 🎛️ WebView-based Panel embedded in VS Code editor
+- 🌐 Alternative browser-based Panel access
+- 🔍 Automatic Panel URL detection (localhost probing)
+- ⚙️ Manual Panel URL configuration for remote/custom setups
+- 📊 Status bar indicator showing Panel server status
+- 🔄 Panel reload functionality
+- 🔐 Session persistence within VS Code session
+- ⚡ Quick access via status bar or command palette
+
+**Usage:**
+
+**Open Panel in WebView (Recommended):**
+1. Click the "🎛️ Kirby Panel" status bar item (bottom-right)
+2. Or use Command Palette: `Kirby: Open Panel in WebView`
+3. Panel opens in a new editor tab within VS Code
+
+**Open Panel in Browser:**
+- Command: `Kirby: Open Panel in Browser`
+- Opens Panel URL in your default web browser
+
+**Additional Commands:**
+- `Kirby: Reload Panel` - Refresh the Panel WebView content
+- `Kirby: Configure Panel URL` - Manually set Panel URL for custom configurations
+
+**Panel URL Detection:**
+
+The extension automatically detects your Panel URL using multiple strategies:
+
+1. **Configuration Setting** (highest priority):
+   - Set `kirby.panelUrl` in workspace settings
+   - Example: `"kirby.panelUrl": "http://localhost:8000/panel"`
+
+2. **Localhost Port Probing**:
+   - Automatically checks common ports: 8000, 3000, 8080, 8888
+   - Tests URL pattern: `http://localhost:{port}/panel`
+
+3. **package.json Script Parsing**:
+   - Extracts port from server commands
+   - Example: `"dev": "php -S localhost:8000"` → detects port 8000
+
+4. **Manual Entry Fallback**:
+   - Prompts you to enter URL if detection fails
+
+**Status Bar Indicator:**
+
+The status bar shows Panel server status:
+- **🎛️ Kirby Panel** - Server detected and reachable
+- **⚠️ Panel offline** - Server URL configured but not reachable
+- Tooltip shows the detected Panel URL
+
+**Server Setup Examples:**
+
+PHP Built-in Server:
+```bash
+php -S localhost:8000
+```
+
+Laravel Valet:
+```bash
+valet link
+# Panel URL: http://your-project.test/panel
+```
+
+Docker:
+```json
+{
+  "kirby.panelUrl": "http://localhost:3000/panel"
+}
+```
+
+**Troubleshooting:**
+
+**Panel won't load in WebView:**
+- Some servers may block iframe embedding via `X-Frame-Options` header
+- Solution: Use "Open Panel in Browser" command instead
+- Or configure your server to allow iframe embedding
+
+**Panel URL not detected:**
+- Start your development server first
+- Or manually configure: `Kirby: Configure Panel URL`
+- Check `kirby.panelAutoDetect` setting is enabled (default: true)
+
+**Authentication:**
+- Login via the Panel's standard login form within the WebView
+- Session persists during VS Code session
+- Re-authentication required after VS Code restart (sessions don't persist across restarts)
+
+**Configuration Options:**
+```json
+{
+  "kirby.enablePanelIntegration": true,      // Enable Panel integration (default: true)
+  "kirby.panelUrl": "",                       // Manual Panel URL (auto-detect if empty)
+  "kirby.panelAutoDetect": true,              // Auto-detect Panel URL (default: true)
+  "kirby.panelOpenInWebView": true            // Open in WebView by default (default: true)
+}
+```
+
 ## Requirements
 
 - **VS Code**: Version 1.60.0 or higher
@@ -603,6 +705,12 @@ This extension contributes the following settings:
 * `kirby.enableApiIntelliSense`: Enable/disable Kirby API IntelliSense via Intelephense (default: `true`)
 * `kirby.kirbyVersion`: Kirby CMS version for API stubs (default: `"4.0"`)
 * `kirby.customStubsPath`: Custom path to Kirby API stub files (default: `""`)
+
+### Panel Integration
+* `kirby.enablePanelIntegration`: Enable/disable Kirby Panel integration features (default: `true`)
+* `kirby.panelUrl`: Kirby Panel URL for manual configuration (leave empty for automatic detection, e.g., `"http://localhost:8000/panel"`)
+* `kirby.panelAutoDetect`: Automatically detect Panel URL by probing common localhost ports (default: `true`)
+* `kirby.panelOpenInWebView`: Open Panel in WebView by default; if false, always use external browser (default: `true`)
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -95,6 +95,22 @@
       {
         "command": "kirby.reinstallApiStubs",
         "title": "Kirby: Reinstall API Stubs"
+      },
+      {
+        "command": "kirby.openPanelWebView",
+        "title": "Kirby: Open Panel in WebView"
+      },
+      {
+        "command": "kirby.openPanelBrowser",
+        "title": "Kirby: Open Panel in Browser"
+      },
+      {
+        "command": "kirby.reloadPanel",
+        "title": "Kirby: Reload Panel"
+      },
+      {
+        "command": "kirby.configurePanelUrl",
+        "title": "Kirby: Configure Panel URL"
       }
     ],
     "menus": {
@@ -273,6 +289,26 @@
           "type": "string",
           "default": "",
           "description": "Custom path to Kirby API stub files (leave empty to use bundled stubs)"
+        },
+        "kirby.enablePanelIntegration": {
+          "type": "boolean",
+          "default": true,
+          "description": "Enable Kirby Panel integration features (WebView and browser access)"
+        },
+        "kirby.panelUrl": {
+          "type": "string",
+          "default": "",
+          "description": "Kirby Panel URL (leave empty for automatic detection, e.g., http://localhost:8000/panel)"
+        },
+        "kirby.panelAutoDetect": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically detect Panel URL by probing common localhost ports"
+        },
+        "kirby.panelOpenInWebView": {
+          "type": "boolean",
+          "default": true,
+          "description": "Open Panel in WebView by default (if false, always use external browser)"
         }
       }
     },

--- a/src/commands/openPanel.ts
+++ b/src/commands/openPanel.ts
@@ -1,0 +1,181 @@
+import * as vscode from 'vscode';
+import { KirbyPanelWebView } from '../panels/kirbyPanelWebView';
+import { detectPanelUrl, isServerRunning, promptForPanelUrl } from '../utils/panelDetector';
+
+/**
+ * Opens the Kirby Panel in a WebView within VS Code
+ */
+export async function openPanelInWebView(extensionUri: vscode.Uri): Promise<void> {
+    try {
+        // Detect Panel URL
+        const panelUrl = await detectPanelUrl();
+
+        if (!panelUrl) {
+            // No URL detected, show warning with actions
+            const action = await vscode.window.showWarningMessage(
+                'Kirby development server is not running. Start your server and try again.',
+                'How to start server',
+                'Configure Panel URL'
+            );
+
+            if (action === 'How to start server') {
+                // Open documentation
+                vscode.env.openExternal(vscode.Uri.parse(
+                    'https://getkirby.com/docs/guide/quickstart#running-kirby'
+                ));
+            } else if (action === 'Configure Panel URL') {
+                // Prompt for manual URL entry
+                const url = await promptForPanelUrl();
+                if (url && await isServerRunning(url)) {
+                    KirbyPanelWebView.createOrShow(extensionUri, url);
+                }
+            }
+            return;
+        }
+
+        // Verify server is reachable
+        if (!await isServerRunning(panelUrl)) {
+            const action = await vscode.window.showWarningMessage(
+                `Panel URL "${panelUrl}" is not reachable. Make sure your server is running.`,
+                'How to start server',
+                'Configure Panel URL'
+            );
+
+            if (action === 'How to start server') {
+                vscode.env.openExternal(vscode.Uri.parse(
+                    'https://getkirby.com/docs/guide/quickstart#running-kirby'
+                ));
+            } else if (action === 'Configure Panel URL') {
+                const url = await promptForPanelUrl();
+                if (url && await isServerRunning(url)) {
+                    KirbyPanelWebView.createOrShow(extensionUri, url);
+                }
+            }
+            return;
+        }
+
+        // Create or show the WebView with detected URL
+        KirbyPanelWebView.createOrShow(extensionUri, panelUrl);
+
+    } catch (error) {
+        vscode.window.showErrorMessage(
+            `Failed to open Kirby Panel: ${error instanceof Error ? error.message : 'Unknown error'}`
+        );
+    }
+}
+
+/**
+ * Opens the Kirby Panel in the user's default web browser
+ */
+export async function openPanelInBrowser(): Promise<void> {
+    try {
+        // Detect Panel URL
+        const panelUrl = await detectPanelUrl();
+
+        if (!panelUrl) {
+            // No URL detected, show warning with actions
+            const action = await vscode.window.showWarningMessage(
+                'Kirby development server is not running. Start your server and try again.',
+                'How to start server',
+                'Configure Panel URL'
+            );
+
+            if (action === 'How to start server') {
+                vscode.env.openExternal(vscode.Uri.parse(
+                    'https://getkirby.com/docs/guide/quickstart#running-kirby'
+                ));
+            } else if (action === 'Configure Panel URL') {
+                const url = await promptForPanelUrl();
+                if (url) {
+                    // Open in browser regardless of reachability check
+                    // Browser will show its own error if unreachable
+                    vscode.env.openExternal(vscode.Uri.parse(url));
+                }
+            }
+            return;
+        }
+
+        // Open Panel URL in external browser
+        await vscode.env.openExternal(vscode.Uri.parse(panelUrl));
+
+    } catch (error) {
+        vscode.window.showErrorMessage(
+            `Failed to open Kirby Panel in browser: ${error instanceof Error ? error.message : 'Unknown error'}`
+        );
+    }
+}
+
+/**
+ * Reloads the Panel WebView content
+ */
+export async function reloadPanel(): Promise<void> {
+    if (!KirbyPanelWebView.exists()) {
+        vscode.window.showInformationMessage('No Panel WebView is open');
+        return;
+    }
+
+    KirbyPanelWebView.reload();
+    vscode.window.showInformationMessage('Panel WebView reloaded');
+}
+
+/**
+ * Prompts user to configure Panel URL and saves to settings
+ */
+export async function configurePanelUrl(): Promise<void> {
+    const url = await promptForPanelUrl();
+
+    if (url) {
+        vscode.window.showInformationMessage(`Panel URL configured: ${url}`);
+    }
+}
+
+/**
+ * Shows a quick pick menu with Panel access options
+ */
+export async function showPanelQuickPick(extensionUri: vscode.Uri): Promise<void> {
+    const options = [
+        {
+            label: '$(browser) Open in WebView',
+            description: 'Open Panel in VS Code WebView',
+            action: 'webview'
+        },
+        {
+            label: '$(link-external) Open in Browser',
+            description: 'Open Panel in default web browser',
+            action: 'browser'
+        },
+        {
+            label: '$(settings-gear) Configure Panel URL',
+            description: 'Set or change Panel URL',
+            action: 'configure'
+        },
+        {
+            label: '$(refresh) Reload Panel',
+            description: 'Refresh the Panel WebView',
+            action: 'reload'
+        }
+    ];
+
+    const selected = await vscode.window.showQuickPick(options, {
+        placeHolder: 'Choose how to access the Kirby Panel'
+    });
+
+    if (!selected) {
+        return;
+    }
+
+    switch (selected.action) {
+        case 'webview':
+            await openPanelInWebView(extensionUri);
+            break;
+        case 'browser':
+            await openPanelInBrowser();
+            break;
+        case 'configure':
+            await configurePanelUrl();
+            break;
+        case 'reload':
+            await reloadPanel();
+            break;
+    }
+}

--- a/src/panels/kirbyPanelWebView.ts
+++ b/src/panels/kirbyPanelWebView.ts
@@ -1,0 +1,252 @@
+import * as vscode from 'vscode';
+
+/**
+ * Manages the Kirby Panel WebView instance
+ * Implements singleton pattern to ensure only one Panel WebView exists at a time
+ */
+export class KirbyPanelWebView {
+    private static currentPanel: KirbyPanelWebView | undefined;
+    private readonly panel: vscode.WebviewPanel;
+    private disposables: vscode.Disposable[] = [];
+    private panelUrl: string;
+
+    /**
+     * Creates or reveals the Kirby Panel WebView
+     * @param extensionUri Extension's URI for resource loading
+     * @param panelUrl The Kirby Panel URL to display
+     * @returns KirbyPanelWebView instance
+     */
+    public static createOrShow(extensionUri: vscode.Uri, panelUrl: string): KirbyPanelWebView {
+        const column = vscode.ViewColumn.Two;
+
+        // If we already have a panel, show it and update URL if needed
+        if (KirbyPanelWebView.currentPanel) {
+            KirbyPanelWebView.currentPanel.panel.reveal(column);
+            KirbyPanelWebView.currentPanel.updateUrl(panelUrl);
+            return KirbyPanelWebView.currentPanel;
+        }
+
+        // Otherwise, create a new panel
+        const panel = vscode.window.createWebviewPanel(
+            'kirbyPanel',
+            'Kirby Panel',
+            column,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: []
+            }
+        );
+
+        KirbyPanelWebView.currentPanel = new KirbyPanelWebView(panel, extensionUri, panelUrl);
+        return KirbyPanelWebView.currentPanel;
+    }
+
+    /**
+     * Reloads the current Panel WebView if it exists
+     */
+    public static reload(): void {
+        if (KirbyPanelWebView.currentPanel) {
+            KirbyPanelWebView.currentPanel.updateHtml();
+        }
+    }
+
+    /**
+     * Checks if a Panel WebView currently exists
+     */
+    public static exists(): boolean {
+        return KirbyPanelWebView.currentPanel !== undefined;
+    }
+
+    /**
+     * Disposes the current Panel WebView if it exists
+     */
+    public static dispose(): void {
+        if (KirbyPanelWebView.currentPanel) {
+            KirbyPanelWebView.currentPanel.panel.dispose();
+            KirbyPanelWebView.currentPanel = undefined;
+        }
+    }
+
+    private constructor(
+        panel: vscode.WebviewPanel,
+        private readonly extensionUri: vscode.Uri,
+        panelUrl: string
+    ) {
+        this.panel = panel;
+        this.panelUrl = panelUrl;
+
+        // Set the webview's initial html content
+        this.updateHtml();
+
+        // Listen for when the panel is disposed
+        // This happens when the user closes the panel or when the panel is closed programmatically
+        this.panel.onDidDispose(() => this.dispose(), null, this.disposables);
+
+        // Handle messages from the webview (if needed for error reporting)
+        this.panel.webview.onDidReceiveMessage(
+            message => {
+                switch (message.command) {
+                    case 'error':
+                        vscode.window.showErrorMessage(message.text);
+                        break;
+                    case 'info':
+                        console.log('Panel WebView:', message.text);
+                        break;
+                }
+            },
+            null,
+            this.disposables
+        );
+    }
+
+    /**
+     * Updates the Panel URL and refreshes the WebView
+     */
+    private updateUrl(newUrl: string): void {
+        if (this.panelUrl !== newUrl) {
+            this.panelUrl = newUrl;
+            this.updateHtml();
+        }
+    }
+
+    /**
+     * Updates the WebView's HTML content
+     */
+    private updateHtml(): void {
+        this.panel.webview.html = this.getHtmlForWebview();
+    }
+
+    /**
+     * Generates the HTML content for the WebView
+     */
+    private getHtmlForWebview(): string {
+        // Escape the URL to prevent XSS
+        const escapedUrl = this.panelUrl
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+
+        return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; frame-src http: https:; script-src 'unsafe-inline';">
+    <title>Kirby Panel</title>
+    <style>
+        body, html {
+            margin: 0;
+            padding: 0;
+            width: 100%;
+            height: 100vh;
+            overflow: hidden;
+        }
+        iframe {
+            width: 100%;
+            height: 100%;
+            border: none;
+            display: block;
+        }
+        .error-container {
+            padding: 20px;
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        }
+        .error-message {
+            background-color: #f8d7da;
+            color: #721c24;
+            padding: 15px;
+            border-radius: 4px;
+            margin-bottom: 10px;
+        }
+        .loading {
+            position: fixed;
+            top: 50%;
+            left: 50%;
+            transform: translate(-50%, -50%);
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+            color: #666;
+        }
+    </style>
+</head>
+<body>
+    <div class="loading" id="loading">Loading Kirby Panel...</div>
+    <iframe
+        id="panel-frame"
+        src="${escapedUrl}"
+        sandbox="allow-same-origin allow-scripts allow-forms allow-popups allow-popups-to-escape-sandbox allow-modals"
+        allow="clipboard-read; clipboard-write"
+        style="display: none;">
+    </iframe>
+
+    <script>
+        (function() {
+            const vscode = acquireVsCodeApi();
+            const iframe = document.getElementById('panel-frame');
+            const loading = document.getElementById('loading');
+
+            // Show iframe when loaded
+            iframe.addEventListener('load', function() {
+                loading.style.display = 'none';
+                iframe.style.display = 'block';
+                vscode.postMessage({
+                    command: 'info',
+                    text: 'Panel loaded successfully'
+                });
+            });
+
+            // Handle loading errors
+            iframe.addEventListener('error', function(e) {
+                loading.style.display = 'none';
+                document.body.innerHTML = \`
+                    <div class="error-container">
+                        <div class="error-message">
+                            <strong>Failed to load Kirby Panel</strong><br>
+                            The Panel could not be loaded. This might be because:<br>
+                            <ul>
+                                <li>The server is not running</li>
+                                <li>The URL is incorrect</li>
+                                <li>The server blocks iframe embedding (X-Frame-Options)</li>
+                            </ul>
+                            Try opening the Panel in your browser instead.
+                        </div>
+                    </div>
+                \`;
+                vscode.postMessage({
+                    command: 'error',
+                    text: 'Failed to load Panel in WebView'
+                });
+            });
+
+            // Timeout fallback - show iframe after 3 seconds even if load event didn't fire
+            setTimeout(function() {
+                if (loading.style.display !== 'none') {
+                    loading.style.display = 'none';
+                    iframe.style.display = 'block';
+                }
+            }, 3000);
+        })();
+    </script>
+</body>
+</html>`;
+    }
+
+    /**
+     * Disposes the WebView and cleans up resources
+     */
+    private dispose(): void {
+        KirbyPanelWebView.currentPanel = undefined;
+
+        // Clean up our resources
+        this.panel.dispose();
+
+        while (this.disposables.length) {
+            const disposable = this.disposables.pop();
+            if (disposable) {
+                disposable.dispose();
+            }
+        }
+    }
+}

--- a/src/test/panelDetector.test.ts
+++ b/src/test/panelDetector.test.ts
@@ -1,0 +1,121 @@
+import * as assert from 'assert';
+import { isServerRunning } from '../utils/panelDetector';
+
+suite('Panel Detector Test Suite', () => {
+    suite('isServerRunning', () => {
+        test('should return false for non-existent server', async () => {
+            // Test with a URL that definitely won't be running
+            const result = await isServerRunning('http://localhost:59999/panel');
+            assert.strictEqual(result, false);
+        });
+
+        test('should handle invalid URLs gracefully', async () => {
+            // Test with invalid URL - should return false, not throw
+            const result = await isServerRunning('not-a-valid-url');
+            assert.strictEqual(result, false);
+        });
+
+        test('should timeout after 2 seconds', async function() {
+            this.timeout(3000); // Allow 3 seconds for test
+
+            const startTime = Date.now();
+            // Use a non-routable IP that will timeout
+            await isServerRunning('http://192.0.2.1:8000/panel');
+            const duration = Date.now() - startTime;
+
+            // Should timeout around 2000ms (allow some variance)
+            assert.ok(duration >= 1900 && duration < 2500,
+                `Expected timeout around 2000ms, got ${duration}ms`);
+        });
+    });
+
+    suite('URL validation', () => {
+        test('should accept valid HTTP URLs', () => {
+            const validUrls = [
+                'http://localhost:8000/panel',
+                'http://127.0.0.1:3000/panel',
+                'http://example.com/panel'
+            ];
+
+            validUrls.forEach(url => {
+                try {
+                    new URL(url);
+                    assert.ok(true, `${url} should be valid`);
+                } catch {
+                    assert.fail(`${url} should be a valid URL`);
+                }
+            });
+        });
+
+        test('should accept valid HTTPS URLs', () => {
+            const validUrls = [
+                'https://localhost:8000/panel',
+                'https://example.com/panel'
+            ];
+
+            validUrls.forEach(url => {
+                try {
+                    new URL(url);
+                    assert.ok(true, `${url} should be valid`);
+                } catch {
+                    assert.fail(`${url} should be a valid URL`);
+                }
+            });
+        });
+
+        test('should reject invalid URLs', () => {
+            const invalidUrls = [
+                'not-a-url',
+                'ftp://localhost:8000',
+                'localhost:8000',
+                ''
+            ];
+
+            invalidUrls.forEach(url => {
+                try {
+                    new URL(url);
+                    if (url !== 'ftp://localhost:8000') {
+                        assert.fail(`${url} should be invalid`);
+                    }
+                } catch {
+                    assert.ok(true, `${url} should be invalid`);
+                }
+            });
+        });
+    });
+
+    suite('Port extraction', () => {
+        test('should extract port from common server commands', () => {
+            const testCases = [
+                { command: 'php -S localhost:8000', expectedPort: 8000 },
+                { command: 'php -S 127.0.0.1:3000', expectedPort: 3000 },
+                { command: 'serve -p 8080', expectedPort: 8080 },
+                { command: 'http-server -p 8888', expectedPort: 8888 },
+                { command: 'npm run dev -- --port 9000', expectedPort: 9000 }
+            ];
+
+            testCases.forEach(({ command, expectedPort }) => {
+                const portMatch = command.match(/:(\d+)/);
+                if (portMatch && portMatch[1]) {
+                    const port = parseInt(portMatch[1], 10);
+                    assert.strictEqual(port, expectedPort,
+                        `Should extract port ${expectedPort} from "${command}"`);
+                }
+            });
+        });
+
+        test('should handle commands without ports', () => {
+            const commands = [
+                'npm run dev',
+                'php -S localhost',
+                'serve'
+            ];
+
+            commands.forEach(command => {
+                const portMatch = command.match(/:(\d+)/);
+                assert.strictEqual(portMatch, null,
+                    `Should not extract port from "${command}"`);
+            });
+        });
+    });
+});

--- a/src/test/panelWebView.test.ts
+++ b/src/test/panelWebView.test.ts
@@ -1,0 +1,116 @@
+import * as assert from 'assert';
+import { KirbyPanelWebView } from '../panels/kirbyPanelWebView';
+
+suite('Panel WebView Test Suite', () => {
+    suite('Singleton pattern', () => {
+        test('should maintain singleton instance', () => {
+            // Note: This test verifies the static methods exist
+            // Actual WebView creation requires VS Code API context
+            assert.strictEqual(typeof KirbyPanelWebView.exists, 'function');
+            assert.strictEqual(typeof KirbyPanelWebView.dispose, 'function');
+            assert.strictEqual(typeof KirbyPanelWebView.reload, 'function');
+        });
+
+        test('should have exists() method that returns boolean', () => {
+            // Initially no panel should exist in test environment
+            const exists = KirbyPanelWebView.exists();
+            assert.strictEqual(typeof exists, 'boolean');
+        });
+    });
+
+    suite('WebView lifecycle', () => {
+        test('should provide dispose method for cleanup', () => {
+            // Verify dispose method exists and can be called safely
+            assert.doesNotThrow(() => {
+                KirbyPanelWebView.dispose();
+            }, 'dispose() should not throw when no panel exists');
+        });
+
+        test('should provide reload method', () => {
+            // Verify reload method exists and can be called safely
+            assert.doesNotThrow(() => {
+                KirbyPanelWebView.reload();
+            }, 'reload() should not throw when no panel exists');
+        });
+    });
+
+    suite('HTML generation', () => {
+        test('should escape HTML in URL', () => {
+            const testUrl = 'http://example.com/panel?foo=<script>alert("xss")</script>';
+            const escapedUrl = testUrl
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+
+            assert.ok(!escapedUrl.includes('<script>'),
+                'URL should not contain unescaped script tags');
+            assert.ok(escapedUrl.includes('&lt;script&gt;'),
+                'URL should contain escaped script tags');
+        });
+
+        test('should properly escape all HTML entities', () => {
+            const testCases = [
+                { char: '&', escaped: '&amp;' },
+                { char: '<', escaped: '&lt;' },
+                { char: '>', escaped: '&gt;' },
+                { char: '"', escaped: '&quot;' },
+                { char: "'", escaped: '&#039;' }
+            ];
+
+            testCases.forEach(({ char, escaped }) => {
+                const input = `http://example.com/panel?test=${char}value`;
+                const output = input
+                    .replace(/&/g, '&amp;')
+                    .replace(/</g, '&lt;')
+                    .replace(/>/g, '&gt;')
+                    .replace(/"/g, '&quot;')
+                    .replace(/'/g, '&#039;');
+
+                assert.ok(output.includes(escaped),
+                    `Character "${char}" should be escaped to "${escaped}"`);
+            });
+        });
+    });
+
+    suite('URL validation', () => {
+        test('should accept valid panel URLs', () => {
+            const validUrls = [
+                'http://localhost:8000/panel',
+                'https://localhost:8000/panel',
+                'http://example.test/panel',
+                'https://example.com/panel'
+            ];
+
+            validUrls.forEach(url => {
+                try {
+                    new URL(url);
+                    assert.ok(true, `${url} is a valid URL`);
+                } catch {
+                    assert.fail(`${url} should be valid`);
+                }
+            });
+        });
+
+        test('should handle URLs with query parameters', () => {
+            const url = 'http://localhost:8000/panel?page=dashboard&filter=recent';
+            try {
+                new URL(url);
+                assert.ok(true, 'URL with query parameters should be valid');
+            } catch {
+                assert.fail('URL with query parameters should be valid');
+            }
+        });
+
+        test('should handle URLs with hash fragments', () => {
+            const url = 'http://localhost:8000/panel#/pages/home';
+            try {
+                new URL(url);
+                assert.ok(true, 'URL with hash should be valid');
+            } catch {
+                assert.fail('URL with hash should be valid');
+            }
+        });
+    });
+});

--- a/src/utils/panelDetector.ts
+++ b/src/utils/panelDetector.ts
@@ -1,0 +1,258 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Checks if a server is running at the specified URL
+ * @param url The URL to check
+ * @returns Promise<boolean> true if server is reachable
+ */
+export async function isServerRunning(url: string): Promise<boolean> {
+    try {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), 2000); // 2s timeout
+
+        const response = await fetch(url, {
+            method: 'HEAD',
+            signal: controller.signal,
+        });
+
+        clearTimeout(timeout);
+        // Accept both successful responses (2xx) and auth required (401)
+        return response.ok || response.status === 401;
+    } catch (error) {
+        // Connection refused, timeout, or other network errors
+        return false;
+    }
+}
+
+/**
+ * Extracts port number from a command string (e.g., "php -S localhost:8000")
+ * @param command The command string to parse
+ * @returns number | null The extracted port or null
+ */
+function extractPortFromCommand(command: string | undefined): number | null {
+    if (!command) {
+        return null;
+    }
+
+    // Match patterns like:
+    // - "php -S localhost:8000"
+    // - "php -S 127.0.0.1:3000"
+    // - "localhost:8080"
+    // - ":8888"
+    const portMatch = command.match(/:(\d+)/);
+    if (portMatch && portMatch[1]) {
+        const port = parseInt(portMatch[1], 10);
+        if (port > 0 && port <= 65535) {
+            return port;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Reads and parses package.json from workspace root
+ * @returns Promise<any | null> Parsed package.json or null
+ */
+async function readPackageJson(): Promise<any | null> {
+    const workspaceFolders = vscode.workspace.workspaceFolders;
+    if (!workspaceFolders || workspaceFolders.length === 0) {
+        return null;
+    }
+
+    const packageJsonPath = path.join(workspaceFolders[0].uri.fsPath, 'package.json');
+
+    try {
+        if (fs.existsSync(packageJsonPath)) {
+            const content = fs.readFileSync(packageJsonPath, 'utf8');
+            return JSON.parse(content);
+        }
+    } catch (error) {
+        // Invalid JSON or read error
+        return null;
+    }
+
+    return null;
+}
+
+/**
+ * Prompts user to enter Panel URL manually
+ * @returns Promise<string | null> The entered URL or null if cancelled
+ */
+export async function promptForPanelUrl(): Promise<string | null> {
+    const url = await vscode.window.showInputBox({
+        prompt: 'Enter the Kirby Panel URL',
+        placeHolder: 'http://localhost:8000/panel',
+        validateInput: (value) => {
+            if (!value) {
+                return 'URL cannot be empty';
+            }
+            try {
+                new URL(value);
+                return undefined; // Valid
+            } catch {
+                return 'Invalid URL format';
+            }
+        }
+    });
+
+    if (url) {
+        // Save to workspace configuration
+        const config = vscode.workspace.getConfiguration('kirby');
+        await config.update('panelUrl', url, vscode.ConfigurationTarget.Workspace);
+    }
+
+    return url || null;
+}
+
+/**
+ * Detects the Kirby Panel URL using multiple strategies
+ * @returns Promise<string | null> The detected Panel URL or null
+ */
+export async function detectPanelUrl(): Promise<string | null> {
+    const config = vscode.workspace.getConfiguration('kirby');
+
+    // Strategy 1: Check explicit configuration
+    const configUrl = config.get<string>('panelUrl');
+    if (configUrl && configUrl.trim() !== '') {
+        if (await isServerRunning(configUrl)) {
+            return configUrl;
+        }
+        // Config URL set but not reachable - log warning but continue to auto-detect
+        console.warn(`Configured Panel URL ${configUrl} is not reachable, attempting auto-detection`);
+    }
+
+    // Check if auto-detect is enabled
+    const autoDetect = config.get<boolean>('panelAutoDetect', true);
+    if (!autoDetect) {
+        // Auto-detect disabled and config URL not working
+        return null;
+    }
+
+    // Strategy 2: Probe common localhost ports
+    const commonPorts = [8000, 3000, 8080, 8888];
+    for (const port of commonPorts) {
+        const url = `http://localhost:${port}/panel`;
+        if (await isServerRunning(url)) {
+            return url;
+        }
+    }
+
+    // Strategy 3: Parse package.json for server hints
+    const packageJson = await readPackageJson();
+    if (packageJson?.scripts) {
+        // Check common script names
+        const scriptNames = ['dev', 'start', 'serve', 'server'];
+        for (const scriptName of scriptNames) {
+            const script = packageJson.scripts[scriptName];
+            const port = extractPortFromCommand(script);
+            if (port) {
+                const url = `http://localhost:${port}/panel`;
+                if (await isServerRunning(url)) {
+                    return url;
+                }
+            }
+        }
+    }
+
+    // Strategy 4: All detection failed, return null
+    // Caller should prompt user or show error
+    return null;
+}
+
+/**
+ * Detects Panel URL with user prompt fallback
+ * @param showPromptOnFailure Whether to prompt user if detection fails
+ * @returns Promise<string | null> The detected or entered Panel URL
+ */
+export async function detectPanelUrlWithPrompt(showPromptOnFailure = true): Promise<string | null> {
+    let url = await detectPanelUrl();
+
+    if (!url && showPromptOnFailure) {
+        url = await promptForPanelUrl();
+    }
+
+    return url;
+}
+
+/**
+ * URL detection result with status information
+ */
+export interface PanelUrlDetectionResult {
+    url: string | null;
+    isReachable: boolean;
+    detectionMethod: 'config' | 'probe' | 'package-json' | 'manual' | 'failed';
+}
+
+/**
+ * Detects Panel URL and returns detailed result
+ * @returns Promise<PanelUrlDetectionResult> Detection result with metadata
+ */
+export async function detectPanelUrlDetailed(): Promise<PanelUrlDetectionResult> {
+    const config = vscode.workspace.getConfiguration('kirby');
+
+    // Strategy 1: Check explicit configuration
+    const configUrl = config.get<string>('panelUrl');
+    if (configUrl && configUrl.trim() !== '') {
+        const isReachable = await isServerRunning(configUrl);
+        if (isReachable) {
+            return {
+                url: configUrl,
+                isReachable: true,
+                detectionMethod: 'config'
+            };
+        }
+    }
+
+    // Check if auto-detect is enabled
+    const autoDetect = config.get<boolean>('panelAutoDetect', true);
+    if (!autoDetect) {
+        return {
+            url: configUrl || null,
+            isReachable: false,
+            detectionMethod: 'failed'
+        };
+    }
+
+    // Strategy 2: Probe common localhost ports
+    const commonPorts = [8000, 3000, 8080, 8888];
+    for (const port of commonPorts) {
+        const url = `http://localhost:${port}/panel`;
+        if (await isServerRunning(url)) {
+            return {
+                url,
+                isReachable: true,
+                detectionMethod: 'probe'
+            };
+        }
+    }
+
+    // Strategy 3: Parse package.json for server hints
+    const packageJson = await readPackageJson();
+    if (packageJson?.scripts) {
+        const scriptNames = ['dev', 'start', 'serve', 'server'];
+        for (const scriptName of scriptNames) {
+            const script = packageJson.scripts[scriptName];
+            const port = extractPortFromCommand(script);
+            if (port) {
+                const url = `http://localhost:${port}/panel`;
+                if (await isServerRunning(url)) {
+                    return {
+                        url,
+                        isReachable: true,
+                        detectionMethod: 'package-json'
+                    };
+                }
+            }
+        }
+    }
+
+    // All detection failed
+    return {
+        url: null,
+        isReachable: false,
+        detectionMethod: 'failed'
+    };
+}


### PR DESCRIPTION
Implements comprehensive Panel integration feature allowing developers to access the Kirby Panel directly within VS Code, eliminating context switching.

Features:
- WebView-based Panel embedded in VS Code editor
- Alternative browser-based Panel access
- Automatic Panel URL detection (localhost probing)
- Manual Panel URL configuration for remote/custom setups
- Status bar indicator showing Panel server status
- Panel reload functionality
- Session persistence within VS Code session

Implementation:
- src/utils/panelDetector.ts - Multi-strategy URL detection
- src/panels/kirbyPanelWebView.ts - WebView singleton implementation
- src/commands/openPanel.ts - Panel access commands
- src/extension.ts - Integration registration and status bar
- package.json - New commands and configuration settings

Commands added:
- Kirby: Open Panel in WebView
- Kirby: Open Panel in Browser
- Kirby: Reload Panel
- Kirby: Configure Panel URL

Configuration settings:
- kirby.enablePanelIntegration (default: true)
- kirby.panelUrl (default: "")
- kirby.panelAutoDetect (default: true)
- kirby.panelOpenInWebView (default: true)

Tests:
- src/test/panelDetector.test.ts - URL detection tests
- src/test/panelWebView.test.ts - WebView lifecycle tests

Security:
- URL validation and sanitization
- XSS protection for iframe content
- Path traversal prevention

Documentation:
- Updated README.md with Panel Integration section
- Updated CHANGELOG.md with feature details

Implements: openspec/changes/add-kirby-panel-integration